### PR TITLE
近接攻撃の仕様変更、実装と一部ステータスの実装

### DIFF
--- a/Project_Live/Assets/Prefabs/Enemy.prefab
+++ b/Project_Live/Assets/Prefabs/Enemy.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 5801283340682902446}
   - component: {fileID: 3853161783685714211}
   - component: {fileID: -3938511364697873303}
+  - component: {fileID: 5621649024667784325}
   m_Layer: 0
   m_Name: Enemy
   m_TagString: Enemy
@@ -151,6 +152,22 @@ MonoBehaviour:
   attackRange: 2
   moveSpeed: 1.5
   rotateSpeed: 125
+--- !u!114 &5621649024667784325
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3064175969719533876}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1912f7e83dd51714eb71b105fb4d2321, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hp: 100
+  attackPower: 10
+  agility: 10
+  invincibleDuration: 1
 --- !u!1 &7511319128033998684
 GameObject:
   m_ObjectHideFlags: 0

--- a/Project_Live/Assets/Scenes/SampleScene.unity
+++ b/Project_Live/Assets/Scenes/SampleScene.unity
@@ -151,7 +151,7 @@ Transform:
   m_GameObject: {fileID: 369292443}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.27}
+  m_LocalPosition: {x: 0, y: 0, z: 0.3}
   m_LocalScale: {x: 3, y: 0.25, z: 1.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -838,16 +838,38 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e02273863c5cbf4fabba463602f1345, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  target: {fileID: 1113225796}
   comboSteps:
   - hitbox: {fileID: 449447930}
+    baseDamage: 10
     attackDuration: 0.2
     comboResetTime: 0.5
+    windupTime: 0.2
+    attackMoveDistance: 1
+    moveSpeedMultiplier: 0.2
   - hitbox: {fileID: 912281677}
+    baseDamage: 10
     attackDuration: 0.2
     comboResetTime: 0.5
+    windupTime: 0.2
+    attackMoveDistance: 1
+    moveSpeedMultiplier: 0.2
   - hitbox: {fileID: 369292443}
+    baseDamage: 10
     attackDuration: 0.2
     comboResetTime: 0.5
+    windupTime: 0.2
+    attackMoveDistance: 1
+    moveSpeedMultiplier: 0.2
+  - hitbox: {fileID: 952118407}
+    baseDamage: 10
+    attackDuration: 0.2
+    comboResetTime: 0.5
+    windupTime: 0.2
+    attackMoveDistance: 1
+    moveSpeedMultiplier: 0.2
+  playerStatus: {fileID: 0}
+  movePlayer: {fileID: 2072640983}
 --- !u!1 &847291714
 GameObject:
   m_ObjectHideFlags: 0
@@ -945,7 +967,7 @@ Transform:
   m_GameObject: {fileID: 912281677}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0.38268343, w: 0.92387956}
-  m_LocalPosition: {x: 0, y: 0, z: 0.27}
+  m_LocalPosition: {x: 0, y: 0, z: 0.3}
   m_LocalScale: {x: 2, y: 0.25, z: 1.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1055,6 +1077,111 @@ Transform:
   - {fileID: 2119038038}
   m_Father: {fileID: 1113225796}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &952118407
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 952118408}
+  - component: {fileID: 952118411}
+  - component: {fileID: 952118410}
+  - component: {fileID: 952118409}
+  m_Layer: 0
+  m_Name: CloseRange (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &952118408
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 952118407}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.55}
+  m_LocalScale: {x: 4, y: 0.25, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1303064750}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &952118409
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 952118407}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &952118410
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 952118407}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d43b8d8adf820674994512c8a5949fed, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &952118411
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 952118407}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -1443,9 +1570,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfc602c1e50eae444a74a7d8b83c1bb5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dodgeDuration: 1
+  dodgeDuration: 0.5
   dodgeInterval: 1
-  dodgeSpeed: 10
+  dodgeSpeed: 1.5
 --- !u!1 &1186035185
 GameObject:
   m_ObjectHideFlags: 0
@@ -1679,6 +1806,7 @@ Transform:
   - {fileID: 449447931}
   - {fileID: 912281678}
   - {fileID: 369292444}
+  - {fileID: 952118408}
   m_Father: {fileID: 1113225796}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1509137993
@@ -1823,7 +1951,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1524185695}
-  - component: {fileID: 1524185696}
+  - component: {fileID: 1524185697}
   m_Layer: 0
   m_Name: PlayerStatus
   m_TagString: Untagged
@@ -1846,7 +1974,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 766505044}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1524185696
+--- !u!114 &1524185697
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1855,13 +1983,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1524185694}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 193b03622f2d18e488e66daa6008d3ef, type: 3}
+  m_Script: {fileID: 11500000, guid: 0ed2d03de0200374eae112331ea1581a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerRenderer: {fileID: 1509137995}
-  normalMaterial: {fileID: 2100000, guid: 01f946ac36292de4d9f0bce5c0c8482e, type: 2}
-  invincibleMaterial: {fileID: 2100000, guid: 2230e882d25d8a14d8182ae1b9aa424f, type: 2}
-  dodge: {fileID: 1183036782}
+  hp: 100
+  attackPower: 10
+  agility: 10
+  invincibleDuration: 1
 --- !u!1 &1547613835
 GameObject:
   m_ObjectHideFlags: 0
@@ -3184,8 +3312,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   target: {fileID: 1113225796}
-  speed: 10
-  rotationSpeed: 500
+  speed: 1
+  rotationSpeed: 50
+  status: {fileID: 1524185697}
   cameraDirectionCalculator: {fileID: 1186035190}
   dodge: {fileID: 1183036782}
 --- !u!1 &2097959998

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyStatus.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyStatus.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//ì¬ÒFŒKŒ´
+
+public class EnemyStatus : CharacterStatus
+{
+    private void Update()
+    {
+        if (Hp <= 0) Die();
+    }
+
+    void Die()
+    {
+        //Debug.Log("“|‚µ‚½");
+        Destroy(gameObject);
+    }
+}

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyStatus.cs.meta
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1912f7e83dd51714eb71b105fb4d2321
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Scripts/EtcScripts/CharacterStatus.cs
+++ b/Project_Live/Assets/Scripts/EtcScripts/CharacterStatus.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class CharacterStatus : MonoBehaviour
+{
+    [Header("HP")]
+    [SerializeField] float hp = 100;
+
+    [Header("UŒ‚—Í")]
+    [SerializeField] float attackPower = 10f;
+
+    [Header("‘f‘‚³")]
+    [SerializeField] float agility = 10f;
+
+    //[Header("”íƒ_ƒ[ƒWŒã‚É”­¶‚·‚é–³“GŠÔ")]
+    //[SerializeField] float invincibleDuration = 1f;
+
+    public float Hp {  get { return hp; } set { hp = value; } }
+
+    public float AttackPower { get { return attackPower; } set { attackPower = value; } }
+
+    public float Agility { get { return agility; } set { agility = value; } }
+
+    //public float InvincibleDuration { get { return InvincibleDuration; } set { InvincibleDuration = value; } }
+}

--- a/Project_Live/Assets/Scripts/EtcScripts/CharacterStatus.cs.meta
+++ b/Project_Live/Assets/Scripts/EtcScripts/CharacterStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46a164c5b2c7b4346861d9fb00b14456
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Scripts/EtcScripts/HitboxTrigger.cs
+++ b/Project_Live/Assets/Scripts/EtcScripts/HitboxTrigger.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//çÏê¨é“ÅFåKå¥
+
+public class HitboxTrigger : MonoBehaviour
+{
+    [SerializeField] string targetTag = "Enemy";
+    [SerializeField] DamageToEnemy damageToEnemy;
+
+    HashSet<Collider> hitTargets = new HashSet<Collider>();
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag(targetTag) && !hitTargets.Contains(other))
+        {
+            if (damageToEnemy != null)
+                damageToEnemy.TakeDamage(other.gameObject);
+
+            //Debug.Log("ñΩíÜ");
+            hitTargets.Add(other);
+        }
+    }
+
+    private void OnDisable()
+    {
+        ResetHits();
+    }
+
+    public void ResetHits()
+    {
+        hitTargets.Clear();
+    }
+}

--- a/Project_Live/Assets/Scripts/EtcScripts/HitboxTrigger.cs.meta
+++ b/Project_Live/Assets/Scripts/EtcScripts/HitboxTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc0c412be842d834abcc2c404e58d326
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Scripts/EtcScripts/StateScripts.meta
+++ b/Project_Live/Assets/Scripts/EtcScripts/StateScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac14ace6bd98134449250ef95eeb2bd9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Scripts/PlayerScripts/DamageToEnemy.cs
+++ b/Project_Live/Assets/Scripts/PlayerScripts/DamageToEnemy.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//作成者：桑原
+
+public class DamageToEnemy : MonoBehaviour
+{
+    float damage;
+
+    public float Damage { get { return damage; } set { damage = value; } }
+
+    public void TakeDamage(GameObject enemy)
+    {
+        EnemyStatus enemyStatus = enemy.GetComponent<EnemyStatus>();
+
+        if (enemyStatus == null)
+        {
+            Debug.LogWarning("対象が見つかりません");
+            return;
+        }
+
+        enemyStatus.Hp -= damage;
+        //Debug.Log(damage + "ダメージを与えた");
+    }
+}

--- a/Project_Live/Assets/Scripts/PlayerScripts/DamageToEnemy.cs.meta
+++ b/Project_Live/Assets/Scripts/PlayerScripts/DamageToEnemy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 414fbc7d6c568614fb95a7458e0b2bfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Scripts/PlayerScripts/PlayerActionScripts/CloseAttack.cs
+++ b/Project_Live/Assets/Scripts/PlayerScripts/PlayerActionScripts/CloseAttack.cs
@@ -9,86 +9,163 @@ class ComboStep
 {
     [Header("この段の攻撃判定用オブジェクト")]
     [SerializeField] public GameObject hitbox;
+    [Header("この攻撃が与える基本ダメージ")]
+    [SerializeField] public float baseDamage = 10f;
     [Header("当たり判定の持続時間")]
     [SerializeField] public float attackDuration = 0.2f;
-    [Header("次の段に移行可能な猶予時間（超過すると初段に戻る)")]
-    [SerializeField] public float comboResetTime = 1f;   
+    [Header("攻撃判定消滅後、次の段に移行可能な猶予時間")]
+    [SerializeField] public float comboResetTime = 1f;
+    [Header("入力受け付後から攻撃までの時間")]
+    [SerializeField] public float windupTime = 0.2f;
+    [Header("この段の攻撃時に移動する距離")]
+    [SerializeField] public float attackMoveDistance = 1f;
 }
 
 public class CloseAttack : MonoBehaviour
 {
+    [Header("移動を制御するオブジェクト")]
+    [SerializeField] Transform target;
     [Header("コンボ設定")]
-    [SerializeField] List<ComboStep> comboSteps = new List<ComboStep>(); 
+    [SerializeField] List<ComboStep> comboSteps = new List<ComboStep>();
+
+    [Header("必要なコンポーネント")]
+    [SerializeField] PlayerStatus playerStatus;
+    [SerializeField] DamageToEnemy damageToEnemy;
+    [SerializeField] MovePlayer movePlayer;
+
+    public enum AttackState { None, Windup, Attacking, Recovering }
+
+    AttackState attackState = AttackState.None;
 
     int currentComboIndex = 0; //現在のコンボ段階を示す変数
     float lastAttackTime = 0f; //最後に攻撃した時間
-    float attackTimer = 0f; //当たり判定の持続時間用変数
-    bool isAttacking = false; //現在攻撃しているかどうか
+    bool isAttackBuffered = false; //攻撃入力があったかどうか
+    float stateTimer = 0f; //各状態の経過時間の計測用
+
+    float moveSpeedMultiplier = 1f; //攻撃中の移動即と制限用
+    float movedDistance = 0f;
+    float totalMoveDistance = 0f;
+
+    public AttackState CurrentAttackState { get { return attackState; } private set { attackState = value; } }
+
+    public void TryAttack() //攻撃処理（近接攻撃ボタンを押したときに呼ばれる）
+    {
+        if (isAttackBuffered || currentComboIndex >= comboSteps.Count) return;
+
+        isAttackBuffered = true;
+        movePlayer.MoveSpeedMultiplier = 0f; //移動を制限
+        stateTimer = 0f;
+        attackState = AttackState.Windup;
+
+        ComboStep step = comboSteps[currentComboIndex];
+        totalMoveDistance = step.attackMoveDistance;
+        movedDistance = 0f;
+        
+        //Debug.Log(currentComboIndex + 1 + "段目");
+    }
 
     void Update()
     {
-        if (isAttacking)
+        stateTimer += Time.deltaTime;
+
+        HandleAttackMovement();
+
+        switch (attackState)
         {
-            attackTimer -= Time.deltaTime;
+            case AttackState.Windup: //攻撃待機
+                if (stateTimer >= comboSteps[currentComboIndex].windupTime)
+                    BeginAttack();
+                break;
 
-            if (attackTimer <= 0f)
-                EndAttack();
+            case AttackState.Attacking: //攻撃中
+                if (stateTimer >= comboSteps[currentComboIndex].attackDuration)
+                    EndAttack();
+                break;
+
+            case AttackState.Recovering: //攻撃後
+                if (Time.time - lastAttackTime > GetCurrentComboResetTime())
+                    ResetCombo();
+                break;
         }
+    }    
 
-        if (!isAttacking && currentComboIndex != 0 && Time.time - lastAttackTime > GetCurrentComboResetTime())
-            ResetCombo();
-    }
-
-    public void TryAttack() //攻撃処理
+    void BeginAttack() //攻撃開始時の処理
     {
-        if (isAttacking) return;
+        ComboStep step = comboSteps[currentComboIndex];
 
-        if (currentComboIndex < comboSteps.Count)
-        {
-            ComboStep step = comboSteps[currentComboIndex];
+        damageToEnemy.Damage = GetCurrentDamage();
 
-            if (step.hitbox != null)
-                step.hitbox.SetActive(true);
+        if (step.hitbox != null) step.hitbox.SetActive(true);
 
-            attackTimer = step.attackDuration;
-            isAttacking = true;
+        movePlayer.RotationSpeedMultiplier = 0f;
+        
+        stateTimer = 0f;
+        attackState = AttackState.Attacking;
 
-            currentComboIndex++;
-            lastAttackTime = Time.time;
-        }
+        //Debug.Log(currentComboIndex + 1 + "段目発生");
     }
 
     void EndAttack() //発生した攻撃の終了処理
     {
-        int prevIndex = currentComboIndex - 1;
+        ComboStep step = comboSteps[currentComboIndex];
 
-        if (prevIndex >= 0 && prevIndex < comboSteps.Count)
-        {
-            var step = comboSteps[prevIndex];
+        if (step.hitbox != null) step.hitbox.SetActive(false);
 
-            if (step.hitbox != null)
-                step.hitbox.SetActive(false);
-        }
+        movePlayer.RotationSpeedMultiplier = 1f;
 
-        isAttacking = false;
+        lastAttackTime = Time.time;      
+        isAttackBuffered = false;
+        stateTimer = 0f;
+        attackState = AttackState.Recovering;
+
+        //Debug.Log(currentComboIndex + 1 + "段目終了");
+        currentComboIndex++;
     }
 
     void ResetCombo() //コンボ段階の初期化
     {
-        currentComboIndex = 0;
-        isAttacking = false;
-        attackTimer = 0f;
-
         //各当たり判定の無効化
         foreach (var step in comboSteps)
-        {
-            if (step.hitbox != null)
-                step.hitbox.SetActive(false);
-        }
+            if (step.hitbox != null)　step.hitbox.SetActive(false);
+
+        movePlayer.MoveSpeedMultiplier = 1f;
+        isAttackBuffered = false;
+        stateTimer = 0f;
+        attackState = AttackState.None;        
+
+        //Debug.Log(currentComboIndex + "コンボのリセット");
+        currentComboIndex = 0;
     }
 
     float GetCurrentComboResetTime() //次のコンボ段階までの猶予時間の取得
     {
         return comboSteps[currentComboIndex - 1].comboResetTime;
+    }
+
+    void HandleAttackMovement() //攻撃時の前進処理
+    {
+        if (attackState != AttackState.Windup || currentComboIndex >= comboSteps.Count) return;
+
+        ComboStep step = comboSteps[currentComboIndex];
+
+        float duration = step.windupTime; //windupTimeの間に前進を終える
+        float movePerSecond = totalMoveDistance / duration;
+        float moveDelta = movePerSecond * Time.deltaTime;
+
+        float remaining = totalMoveDistance - movedDistance;
+        float actualMove = Mathf.Min(moveDelta, remaining);
+
+        target.position += target.forward.normalized * actualMove;
+        movedDistance += actualMove;
+    }
+
+    float GetCurrentDamage() //現在の段のダメージ量を取得する
+    {
+        if (currentComboIndex >= comboSteps.Count || currentComboIndex < 0) return 0f;
+
+        ComboStep step = comboSteps[currentComboIndex];
+        float attackPower = playerStatus != null ? playerStatus.AttackPower : 1f;
+
+        return step.baseDamage * attackPower; //現在の段の基本ダメージとプレイヤーの攻撃力から最終ダメージを乗算
     }
 }

--- a/Project_Live/Assets/Scripts/PlayerScripts/PlayerActionScripts/MovePlayer.cs
+++ b/Project_Live/Assets/Scripts/PlayerScripts/PlayerActionScripts/MovePlayer.cs
@@ -8,26 +8,36 @@ public class MovePlayer : MonoBehaviour
 {
     [Header("動かすオブジェクト")]
     [SerializeField] Transform target;
-    [Header("移動スピード")]
-    [SerializeField] float speed = 10f;
-    [Header("回転スピード")]
-    [SerializeField] float rotationSpeed = 10f;
+    [Header("移動スピードの倍率")]
+    [SerializeField] float speed = 1f;
+    [Header("回転スピードの倍率")]
+    [SerializeField] float rotationSpeed = 1f;
 
     [Header("必要なコンポーネント")]
-    
+    [SerializeField] PlayerStatus status;
     [SerializeField] CameraDirectionCalculator cameraDirectionCalculator;
     [SerializeField] Dodge dodge;
 
     Vector3 move; //入力値取得用変数
     Vector3 prev_Move = Vector3.zero; //前フレームの移動値保存用変数
-
+    Vector3 prev_Position; //前フレームの位置保存用変数
     Vector3 moveDirection; //移動方向用の変数
+
+    float moveSpeedMultiplier = 1f; //移動量制限用の変数
+    float rotateSpeedMultiplier = 1f; //回転量制限用の変数
 
     public Vector3 Move { get { return move; } }
     public Vector3 Prev_Move { get {  return prev_Move; } }
+    public Vector3 Position { get { return target.position; } }
+    public Vector3 Prev_Position { get { return prev_Position; } }
+
+    public float MoveSpeedMultiplier { get { return moveSpeedMultiplier; } set { moveSpeedMultiplier = value; } }
+    public float RotationSpeedMultiplier { get { return rotateSpeedMultiplier; } set {  rotateSpeedMultiplier = value; } }
 
     void Update()
     {
+        prev_Move = move; //移動の値を保存
+
         if (move.magnitude > 0.1f) //移動の入力があったら
         {
             CalculateMoveDirection();
@@ -35,7 +45,7 @@ public class MovePlayer : MonoBehaviour
             MoveTransform();           
         }
 
-        prev_Move = move; //移動の値を保存
+        prev_Position = target.position; //現在地点を保存
     }
 
     void CalculateMoveDirection() //移動方向の計算
@@ -45,7 +55,7 @@ public class MovePlayer : MonoBehaviour
 
     void MoveTransform() //移動処理
     {    
-        target.transform.position += moveDirection * (speed + dodge.AddDodgeSpeed()) * Time.deltaTime;
+        target.transform.position += moveDirection * (speed + dodge.AddDodgeSpeed()) * moveSpeedMultiplier * status.Agility * Time.deltaTime;
     }
 
     void RotateTransform() //回転処理
@@ -53,7 +63,7 @@ public class MovePlayer : MonoBehaviour
         Quaternion targetRotation = Quaternion.LookRotation(moveDirection, Vector3.up);
 
         //回転速度に制限をかける
-        target.transform.rotation = Quaternion.RotateTowards(target.transform.rotation, targetRotation, rotationSpeed * Time.deltaTime);
+        target.transform.rotation = Quaternion.RotateTowards(target.transform.rotation, targetRotation, rotationSpeed * rotateSpeedMultiplier * status.Agility * Time.deltaTime);
     }
 
     public void GetMoveVector(Vector3 getVec)

--- a/Project_Live/Assets/Scripts/PlayerScripts/PlayerControllerScripts/ControllerOfCloseAttack.cs
+++ b/Project_Live/Assets/Scripts/PlayerScripts/PlayerControllerScripts/ControllerOfCloseAttack.cs
@@ -10,6 +10,8 @@ public class ControllerOfCloseAttack : MonoBehaviour
     [SerializeField] CloseAttack closeAttack;
     [SerializeField] InputAction cancelAction; //アクションを無効化する入力
 
+    public event System.Action OnCloseAttackPerformed;
+
     private void OnEnable()
     {
         cancelAction.Enable();
@@ -25,5 +27,6 @@ public class ControllerOfCloseAttack : MonoBehaviour
         if (!context.performed || cancelAction.IsPressed()) return;
 
         closeAttack.TryAttack(); //近接攻撃処理の呼び出し
+        OnCloseAttackPerformed?.Invoke(); //処理が呼ばれたことを通知する
     }
 }

--- a/Project_Live/Assets/Scripts/PlayerScripts/PlayerControllerScripts/ControllerOfMove.cs
+++ b/Project_Live/Assets/Scripts/PlayerScripts/PlayerControllerScripts/ControllerOfMove.cs
@@ -9,10 +9,15 @@ using UnityEngine.InputSystem;
 public class ControllerOfMove : MonoBehaviour
 {
     [SerializeField] MovePlayer movePlayer;
+
+    //public event System.Action OnCloseMovePerformed;
+
     public void GetInputVector(InputAction.CallbackContext context)
     {
         Vector2 getVec = context.ReadValue<Vector2>(); //入力方向を取得する
         Vector3 moveVec = new Vector3(getVec.x, 0, getVec.y);
         movePlayer.GetMoveVector(moveVec); //プレイヤーの移動スクリプトに値を渡す
+
+        //OnCloseMovePerformed?.Invoke(); //処理が呼ばれたことを通知する
     }
 }

--- a/Project_Live/Assets/Scripts/PlayerScripts/PlayerStatus.cs
+++ b/Project_Live/Assets/Scripts/PlayerScripts/PlayerStatus.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerStatus : CharacterStatus
+{
+
+}

--- a/Project_Live/Assets/Scripts/PlayerScripts/PlayerStatus.cs.meta
+++ b/Project_Live/Assets/Scripts/PlayerScripts/PlayerStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ed2d03de0200374eae112331ea1581a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
変更内容

プレイヤーの攻撃について
・4段目までコンボ攻撃が出せるようにしました。
・各段に設定されている基本ダメージに、プレイヤーの攻撃力を乗算して合計ダメージを算出するようにしました。
・攻撃の際は移動を制限し、攻撃が発動直前に少し前進するようにしました。前進距離はヒエラルキーウィンドウ上で変更可能
　です。

ステータスについて
・プレイヤーと敵にHP、攻撃力などの一部パラメータを実装しました。
・敵を攻撃することで、倒せるようにしました。現在はHpを0以下にすると消滅するようにしています。

コードが複雑になってしまったので、後ほど修正していきます。他の各機能についても、後ほど実装していきます。
