### PR TITLE
複数種類の敵の実装、生成スクリプトの修正

### DIFF
--- a/Project_Live/Assets/Effects/DeathEffect.prefab
+++ b/Project_Live/Assets/Effects/DeathEffect.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 7432352541670770714}
   - component: {fileID: 4630952706036507578}
   - component: {fileID: 662223980953991895}
+  - component: {fileID: -1041063827852562127}
   m_Layer: 0
   m_Name: DeathEffect
   m_TagString: Untagged
@@ -4889,3 +4890,16 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
+--- !u!114 &-1041063827852562127
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2970488489590598586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72b50e7d229de66489b057bbe57c1976, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destroyDelay: 1.5

--- a/Project_Live/Assets/Materials/ElietEnemy.mat
+++ b/Project_Live/Assets/Materials/ElietEnemy.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ElietEnemy
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Project_Live/Assets/Materials/ElietEnemy.mat.meta
+++ b/Project_Live/Assets/Materials/ElietEnemy.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 363c12eec7fcfb346bd29f2398be8e00
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Materials/ShooterEnemy.mat
+++ b/Project_Live/Assets/Materials/ShooterEnemy.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ShooterEnemy
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 0.834098, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Project_Live/Assets/Materials/ShooterEnemy.mat.meta
+++ b/Project_Live/Assets/Materials/ShooterEnemy.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d63a1f98c22543949ae901bc94baf7a2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Prefabs/ElietEnemy.prefab
+++ b/Project_Live/Assets/Prefabs/ElietEnemy.prefab
@@ -1,0 +1,95 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1574039290145936768
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 554825062331645927, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 554825062331645927, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3064175969719533876, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_Name
+      value: ElietEnemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 4515992174774905601, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 363c12eec7fcfb346bd29f2398be8e00, type: 2}
+    - target: {fileID: 5621649024667784325, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: hp
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 6188201578832378370, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 363c12eec7fcfb346bd29f2398be8e00, type: 2}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.8234625
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.0999999
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.184003
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852180878318343403, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: type
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}

--- a/Project_Live/Assets/Prefabs/ElietEnemy.prefab.meta
+++ b/Project_Live/Assets/Prefabs/ElietEnemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0ca38b335cd5ce943841935d2bf66391
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Prefabs/Enemy.prefab
+++ b/Project_Live/Assets/Prefabs/Enemy.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 3853161783685714211}
   - component: {fileID: -3938511364697873303}
   - component: {fileID: 5621649024667784325}
+  - component: {fileID: 8852180878318343403}
   m_Layer: 0
   m_Name: Enemy
   m_TagString: Enemy
@@ -169,8 +170,21 @@ MonoBehaviour:
   agility: 10
   destroyDuration: 0.5
   deathEffect: {fileID: 2970488489590598586, guid: 8bcb93189acc69c4494bebb4c3eb3997, type: 3}
-  knockbackForce_Back: 5
+  knockbackForce_Back: 20
   knockbackForce_Up: 0.5
+--- !u!114 &8852180878318343403
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3064175969719533876}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c2900cc65b231b48b1e2f9b789721e0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 0
 --- !u!1 &7511319128033998684
 GameObject:
   m_ObjectHideFlags: 0

--- a/Project_Live/Assets/Prefabs/ShooterEnemy.prefab
+++ b/Project_Live/Assets/Prefabs/ShooterEnemy.prefab
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4462907832996279773
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 554825062331645927, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 3064175969719533876, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_Name
+      value: ShooterEnemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 4515992174774905601, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: d63a1f98c22543949ae901bc94baf7a2, type: 2}
+    - target: {fileID: 6188201578832378370, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: d63a1f98c22543949ae901bc94baf7a2, type: 2}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.8376484
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6318118443885309351, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852180878318343403, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+      propertyPath: type
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}

--- a/Project_Live/Assets/Prefabs/ShooterEnemy.prefab.meta
+++ b/Project_Live/Assets/Prefabs/ShooterEnemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7ec15a4a766bd5645ad22156012d4566
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Scenes/SampleScene.unity
+++ b/Project_Live/Assets/Scenes/SampleScene.unity
@@ -926,7 +926,7 @@ GameObject:
   - component: {fileID: 847291715}
   - component: {fileID: 847291718}
   m_Layer: 0
-  m_Name: EnamySpawnManager
+  m_Name: EnemySpawnManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -980,8 +980,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 06f9fab46796a094aae21f8c4c4c4768, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  enemyPrefab: {fileID: 3064175969719533876, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
-  maxSpawnCount: 20
+  spawnParameters:
+  - enemyPrefab: {fileID: 3064175969719533876, guid: 7f70ecbc35e196948bcc99c86b346e9b, type: 3}
+    maxSpawnCount: 10
+    enemyType: 0
+  - enemyPrefab: {fileID: 1686963957830972649, guid: 7ec15a4a766bd5645ad22156012d4566, type: 3}
+    maxSpawnCount: 4
+    enemyType: 2
+  - enemyPrefab: {fileID: 4566157072714159284, guid: 0ca38b335cd5ce943841935d2bf66391, type: 3}
+    maxSpawnCount: 1
+    enemyType: 1
   spawnArea: {fileID: 847291715}
   checkInterval: 1
 --- !u!1 &912281677
@@ -3416,7 +3424,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2097959998}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.018189488, y: -0.000000017203536, z: -3.1297526e-10, w: 0.9998346}
+  m_LocalRotation: {x: -0.018189488, y: 0.000000017203536, z: 3.1297526e-10, w: 0.9998346}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemyCountTracker.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemyCountTracker.cs
@@ -4,25 +4,20 @@ using UnityEngine;
 
 public class EnemyCountTracker : MonoBehaviour
 {
-    string enemyTag;
+    EnemyType enemyType;
     int prev_Count;
 
-    public EnemyCountTracker(string enemyTag)
+    public EnemyCountTracker(EnemyType enemyType)
     {
-        this.enemyTag = enemyTag;
-        prev_Count = 0;
-    }
-
-    int GetCurrentCount() //Enemyタグをもつオブジェクトの数を調べる
-    {
-        return GameObject.FindGameObjectsWithTag(enemyTag).Length;
+        this.enemyType = enemyType;
+        prev_Count = -1;
     }
 
     public bool HasChanged(out int currentCount) //敵の数が変わったどうか判定する
     {
-        currentCount = GetCurrentCount();
+        currentCount = EnemyRegistry.GetCount(enemyType);
 
-        if (currentCount !=  prev_Count)
+        if (currentCount != prev_Count)
         {
             prev_Count = currentCount;
             return true;

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemyRegistry.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemyRegistry.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class EnemyRegistry
+{
+    static Dictionary<EnemyType, int> enemyCounts = new();
+
+    public static void Register(EnemyType type) //指定された種類の敵のカウントを増やす
+    {
+        if (!enemyCounts.ContainsKey(type))
+            enemyCounts[type] = 0;
+
+        enemyCounts[type]++;
+    }
+
+    public static void Unregister(EnemyType type) //指定された種類の敵のカウントを減らす
+    {
+        if (!enemyCounts.ContainsKey(type)) return;
+
+        enemyCounts[type]--;
+
+        if (enemyCounts[type] <= 0) enemyCounts[type] = 0;
+     }
+
+    public static int GetCount(EnemyType type) //指定された種類の敵が現在存在している数を取得する
+    {
+        return enemyCounts.TryGetValue(type, out var count) ? count : 0;
+    }
+}

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemyRegistry.cs.meta
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemyRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d80728eaf788aa14b83d71aaa950795d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemySpawnManager.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemySpawnManager.cs
@@ -2,43 +2,57 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[System.Serializable]
+public class SpawnParameter
+{
+    [Header("生成する敵プレハブ")]
+    public GameObject enemyPrefab;
+    [Header("この敵の最大同時出現数")]
+    public int maxSpawnCount;
+    [Header("この敵の種類")]
+    public EnemyType enemyType;
+}
+
 public class EnemySpawnManager : MonoBehaviour
 {
-    [Header("生成するオブジェクト")]
-    [SerializeField] GameObject enemyPrefab;
-    [Header("オブジェクトの最大出現数（この数だけ、敵が常にステージ上にいる")]
-    [SerializeField] int maxSpawnCount = 10;
+    [Header("スポーンさせるオブジェクトの設定")]
+    [SerializeField] List<SpawnParameter> spawnParameters;
     [Header("生成範囲")]
     [SerializeField] BoxCollider spawnArea;
     [Header("敵の数のチェック間隔")]
     [SerializeField] float checkInterval = 1.0f;
 
-    EnemySpawn spawner;
-    EnemyCountTracker tracker;
+    Dictionary<EnemyType, EnemySpawn> spawners = new();
+    Dictionary<EnemyType, EnemyCountTracker> trackers = new();
 
     float timer = 0f;
-
-    // Start is called before the first frame update
     void Start()
     {
-        spawner = new EnemySpawn(enemyPrefab, spawnArea);
-        tracker = new EnemyCountTracker("Enemy");
-
-        spawner.SpawnEnemies(maxSpawnCount);
+        foreach (var param in spawnParameters) //設定された敵の種類の数だけ処理を繰り返す
+        {
+            spawners[param.enemyType] = new EnemySpawn(param.enemyPrefab, spawnArea);
+            trackers[param.enemyType] = new EnemyCountTracker(param.enemyType);
+            spawners[param.enemyType].SpawnEnemies(param.maxSpawnCount); //敵の初期生成
+        }
     }
-
-    // Update is called once per frame
     void Update()
     {
         timer += Time.deltaTime;
 
         if (timer < checkInterval) return;
 
-        if (tracker.HasChanged(out int currentCount)) //敵の数に変化があったら
-        {
-            int toSpawn = maxSpawnCount - currentCount; //敵の設定総数と、現在の数の差分を求める
+        timer = 0f;
 
-            if (toSpawn > 0) spawner.SpawnEnemies(toSpawn); //足りない数だけ敵を生成
+        foreach (var param in spawnParameters)
+        {
+            var tracker = trackers[param.enemyType];
+
+            if (tracker.HasChanged(out int currentCount)) //調べた種類の敵の数が少なくなっていたら
+            {
+                int toSpawn = param.maxSpawnCount - currentCount; //その種類の敵の最大同時出現数と現在の数との差分を求める
+
+                if (toSpawn > 0) spawners[param.enemyType].SpawnEnemies(toSpawn); //少ない分だけ敵を生成する
+            }
         }
     }
 }

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyTypeIdentifier.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyTypeIdentifier.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum EnemyType //“G‚ÌŽí—Þ
+{
+    Normal, Eliet, Shooter
+}
+
+public class EnemyTypeIdentifier : MonoBehaviour
+{
+    public EnemyType type;
+
+    void OnEnable()
+    {
+        EnemyRegistry.Register(type);
+    }
+
+    void OnDestroy()
+    {
+        EnemyRegistry.Unregister(type);
+    }
+}

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyTypeIdentifier.cs.meta
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyTypeIdentifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c2900cc65b231b48b1e2f9b789721e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
実装内容

敵の種類の追加
・通常の敵のほかに、強力な敵と遠距離攻撃を行う敵を実装しました（現時点では、敵の攻撃は未実装です）。

生成用スクリプトの修正
・生成する敵のプレハブを複数登録できるようにしました。種類ごとに最大生成数を調整できます。
・敵プレハブに、種類を持たせるためのスクリプトを追加しました。タグの代わりに、生成時に参照します。