### PR TITLE
特定の操作後、移動できなくなる不具合の修正

### DIFF
--- a/Project_Live/Assets/Scripts/PlayerScripts/PlayerActionScripts/CloseAttack.cs
+++ b/Project_Live/Assets/Scripts/PlayerScripts/PlayerActionScripts/CloseAttack.cs
@@ -57,8 +57,6 @@ public class CloseAttack : MonoBehaviour
         if (isAttackBuffered || currentComboIndex >= comboSteps.Count) return;
 
         isAttackBuffered = true;
-        movePlayer.MoveSpeedMultiplier = 0f; //ˆÚ“®‚ð§ŒÀ
-        //stateTimer = 0f;
         attackState = AttackState.Windup;
 
         ComboStep step = comboSteps[currentComboIndex];
@@ -77,6 +75,7 @@ public class CloseAttack : MonoBehaviour
         switch (attackState)
         {
             case AttackState.Windup: //UŒ‚‘Ò‹@
+                movePlayer.MoveSpeedMultiplier = 0f; //ˆÚ“®‚ð§ŒÀ
                 if (stateTimer >= comboSteps[currentComboIndex].windupTime)
                     BeginAttack();
                 break;


### PR DESCRIPTION
イイネアクション発動中にバズリショットを使用し、近接攻撃ボタンを押すことで、その場から移動できなくなる不具合を修正しました。