### PR TITLE
敵のHPが0になった時に行われる処理の修正

### DIFF
--- a/Project_Live/Assets/Prefabs/EnemyPrefabs/Enemy_Normal.prefab
+++ b/Project_Live/Assets/Prefabs/EnemyPrefabs/Enemy_Normal.prefab
@@ -130,10 +130,10 @@ GameObject:
   - component: {fileID: 8277334614430860953}
   - component: {fileID: 8138021315255765325}
   - component: {fileID: 4098828232468043532}
+  - component: {fileID: 2420152649761166137}
   - component: {fileID: -4404924394619826991}
   - component: {fileID: 4750362542482719141}
   - component: {fileID: 8259107007558549480}
-  - component: {fileID: 2420152649761166137}
   - component: {fileID: 2213797413019997299}
   m_Layer: 0
   m_Name: Enemy_Normal
@@ -204,12 +204,25 @@ MonoBehaviour:
   hp: 10
   attackPower: 10
   agility: 10
-  destroyDuration: 1
+  deathHandler: {fileID: 2420152649761166137}
+--- !u!114 &2420152649761166137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7764904506935383429}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d82797d7eea1a4e479d5e2d73f4b4949, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundStayDuration: 2
+  groundCheckDistance: 0.7
   deathEffect: {fileID: 2970488489590598586, guid: 8bcb93189acc69c4494bebb4c3eb3997, type: 3}
   knockbackForce_Back: 2
   knockbackForce_Up: 30
   getGoodNum: 10
-  deathHandler: {fileID: 2420152649761166137}
 --- !u!114 &-4404924394619826991
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -253,24 +266,7 @@ MonoBehaviour:
   stopRange: 2
   moveSpeed: 3
   rotateSpeed: 35
---- !u!114 &2420152649761166137
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7764904506935383429}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d82797d7eea1a4e479d5e2d73f4b4949, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  destroyDuration: 1
-  deathEffect: {fileID: 2970488489590598586, guid: 8bcb93189acc69c4494bebb4c3eb3997, type: 3}
-  knockbackForce_Back: 2
-  knockbackForce_Up: 30
-  groundStayDuration: 2
-  getGoodNum: 10
+  enemyStatus: {fileID: 4098828232468043532}
 --- !u!54 &2213797413019997299
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Project_Live/Assets/Prefabs/EnemyPrefabs/Enemy_Normal.prefab
+++ b/Project_Live/Assets/Prefabs/EnemyPrefabs/Enemy_Normal.prefab
@@ -49,6 +49,7 @@ MonoBehaviour:
   triggerRange: {fileID: 8850819913040691998}
   targetTag: Player
   triggerDuration: 2
+  enemyStatus: {fileID: 4098828232468043532}
 --- !u!114 &446971775148853601
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -132,6 +133,7 @@ GameObject:
   - component: {fileID: -4404924394619826991}
   - component: {fileID: 4750362542482719141}
   - component: {fileID: 8259107007558549480}
+  - component: {fileID: 2420152649761166137}
   - component: {fileID: 2213797413019997299}
   m_Layer: 0
   m_Name: Enemy_Normal
@@ -207,6 +209,7 @@ MonoBehaviour:
   knockbackForce_Back: 2
   knockbackForce_Up: 30
   getGoodNum: 10
+  deathHandler: {fileID: 2420152649761166137}
 --- !u!114 &-4404924394619826991
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,6 +253,24 @@ MonoBehaviour:
   stopRange: 2
   moveSpeed: 3
   rotateSpeed: 35
+--- !u!114 &2420152649761166137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7764904506935383429}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d82797d7eea1a4e479d5e2d73f4b4949, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destroyDuration: 1
+  deathEffect: {fileID: 2970488489590598586, guid: 8bcb93189acc69c4494bebb4c3eb3997, type: 3}
+  knockbackForce_Back: 2
+  knockbackForce_Up: 30
+  groundStayDuration: 2
+  getGoodNum: 10
 --- !u!54 &2213797413019997299
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Project_Live/Assets/Scripts/EnemyScripts/AttackTrigger.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/AttackTrigger.cs
@@ -10,7 +10,7 @@ public class AttackTrigger : MonoBehaviour
     [SerializeField] string targetTag = "Player";
     
     [Header("攻撃を行うまでに必要な判定時間")]
-    [SerializeField] float triggerDuration = 1f;
+    [SerializeField] float triggerDuration = 0.8f;
 
     [Header("必要なコンポーネント")]
     [SerializeField] EnemyStatus enemyStatus;
@@ -24,7 +24,7 @@ public class AttackTrigger : MonoBehaviour
     {
         if (!other.CompareTag(targetTag)) return; //当たり判定を行うオブジェクトのタグがPlayerでなければ処理を行わない
 
-        if (enemyStatus.IsDead && isAttackTrigger == true) return; //敵のHPが0、または攻撃の処理を開始している場合は何もしない
+        if (enemyStatus.IsDead || isAttackTrigger == true) return; //敵のHPが0、または攻撃の処理を開始している場合は何もしない
 
         currentTimer += Time.deltaTime;
 

--- a/Project_Live/Assets/Scripts/EnemyScripts/AttackTrigger.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/AttackTrigger.cs
@@ -8,10 +8,12 @@ public class AttackTrigger : MonoBehaviour
     [SerializeField] SphereCollider triggerRange;
     [Header("判定を行う対象のオブジェクト")]
     [SerializeField] string targetTag = "Player";
-    //[Header("判定を始めるプレイヤーとの距離")]
-    //[SerializeField] float triggerDistance;
+    
     [Header("攻撃を行うまでに必要な判定時間")]
     [SerializeField] float triggerDuration = 1f;
+
+    [Header("必要なコンポーネント")]
+    [SerializeField] EnemyStatus enemyStatus;
 
     float currentTimer = 0f; //経過時間の測定用
     bool isAttackTrigger = false; //攻撃するかどうか
@@ -22,7 +24,7 @@ public class AttackTrigger : MonoBehaviour
     {
         if (!other.CompareTag(targetTag)) return; //当たり判定を行うオブジェクトのタグがPlayerでなければ処理を行わない
 
-        if (isAttackTrigger == true) return;
+        if (enemyStatus.IsDead && isAttackTrigger == true) return; //敵のHPが0、または攻撃の処理を開始している場合は何もしない
 
         currentTimer += Time.deltaTime;
 

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyDeathHandler.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyDeathHandler.cs
@@ -2,11 +2,11 @@ using UnityEngine;
 
 public class EnemyDeathHandler : MonoBehaviour
 {
-    //[Header("HPが0になってから消えるまでの時間")]
-    //[SerializeField] float destroyDuration = 1f;
-
     [Header("地面に設置してから死亡までの時間")]
-    [SerializeField] float groundStayDuration = 2f;
+    [SerializeField] float groundStayDuration = 1f;
+
+    [Header("地面に設置しているかどうかを判定する距離")]
+    [SerializeField] float groundCheckDistance = 1f;
 
     [Header("撃破時のエフェクト")]
     [SerializeField] GameObject deathEffect;
@@ -20,16 +20,16 @@ public class EnemyDeathHandler : MonoBehaviour
     [Header("いいね獲得数")]
     [SerializeField] float getGoodNum;
 
-    bool isDead = false;
-    public bool IsDead { get { return isDead; } }
+    float groundTimer = 0f;
 
+    bool isDead = false;
     bool isProcessing = false;
+
+    public bool IsDead { get { return isDead; } }
     public bool IsProcessing { get { return isProcessing; } }
 
     Rigidbody rb;
     GoodSystem goodSystem;
-
-    float groundTimer = 0f;
 
     private void Awake()
     {
@@ -41,10 +41,12 @@ public class EnemyDeathHandler : MonoBehaviour
     {
         if (isProcessing)
         {
-            Debug.Log("死亡状態に移行");
+            //Debug.Log("死亡状態に移行");
             if (IsGrounded())
             {
                 groundTimer += Time.deltaTime;
+
+                Debug.Log(groundTimer);
 
                 if (groundTimer >= groundStayDuration) Die(); //地面に設置している状態で一定時間経過後、死亡時の処理を行う
             }
@@ -78,6 +80,6 @@ public class EnemyDeathHandler : MonoBehaviour
 
     private bool IsGrounded() //地面に設置しているかどうかを判定する処理
     {
-        return Physics.Raycast(transform.position, Vector3.down, 1.1f);
+        return Physics.Raycast(transform.position, Vector3.down, groundCheckDistance);
     }
 }

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyDeathHandler.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyDeathHandler.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+public class EnemyDeathHandler : MonoBehaviour
+{
+    //[Header("HPが0になってから消えるまでの時間")]
+    //[SerializeField] float destroyDuration = 1f;
+
+    [Header("地面に設置してから死亡までの時間")]
+    [SerializeField] float groundStayDuration = 2f;
+
+    [Header("撃破時のエフェクト")]
+    [SerializeField] GameObject deathEffect;
+
+    [Header("後ろに吹き飛ばされる力")]
+    [SerializeField] float knockbackForce_Back = 2f;
+
+    [Header("上に吹き飛ばされる力")]
+    [SerializeField] float knockbackForce_Up = 30f;
+
+    [Header("いいね獲得数")]
+    [SerializeField] float getGoodNum;
+
+    bool isDead = false;
+    public bool IsDead { get { return isDead; } }
+
+    bool isProcessing = false;
+    public bool IsProcessing { get { return isProcessing; } }
+
+    Rigidbody rb;
+    GoodSystem goodSystem;
+
+    float groundTimer = 0f;
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody>();
+        goodSystem = GameObject.FindWithTag("GoodSystem").GetComponent<GoodSystem>();
+    }
+
+    private void Update()
+    {
+        if (isProcessing)
+        {
+            Debug.Log("死亡状態に移行");
+            if (IsGrounded())
+            {
+                groundTimer += Time.deltaTime;
+
+                if (groundTimer >= groundStayDuration) Die(); //地面に設置している状態で一定時間経過後、死亡時の処理を行う
+            }
+
+            else groundTimer = 0f; //経過時間のリセット
+        }
+    }
+
+    public void StartDeathProcess() //HPが0になった時に呼ばれる処理
+    {
+        if (isProcessing) return;
+
+        isProcessing = true;
+
+        //のけぞり処理
+        Vector3 backwardForce = -transform.forward * knockbackForce_Back;
+        Vector3 upwardForce = Vector3.up * knockbackForce_Up;
+        rb.AddForce(backwardForce + upwardForce, ForceMode.Impulse);
+        //
+
+        goodSystem.AddGood(getGoodNum);
+    }
+
+    private void Die() //死亡処理
+    {
+        if (deathEffect != null)
+            Instantiate(deathEffect, transform.position, Quaternion.identity);
+
+        Destroy(gameObject);
+    }
+
+    private bool IsGrounded() //地面に設置しているかどうかを判定する処理
+    {
+        return Physics.Raycast(transform.position, Vector3.down, 1.1f);
+    }
+}

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyDeathHandler.cs.meta
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyDeathHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d82797d7eea1a4e479d5e2d73f4b4949

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyMover.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyMover.cs
@@ -15,6 +15,9 @@ public class EnemyMover : MonoBehaviour
     [Header("回転速度")]
     [SerializeField] float rotateSpeed;
 
+    [Header("必要なコンポーネント")]
+    [SerializeField] EnemyStatus enemyStatus;
+
     private Transform lookTarget; //追いかける対象
 
     MoveState moveState;
@@ -27,7 +30,7 @@ public class EnemyMover : MonoBehaviour
 
     void Update()
     {
-        if (lookTarget == null) return;
+        if (enemyStatus.IsDead || lookTarget == null) return; //HPが0、または追いかける対象が見つからない場合
 
         float distance = Vector3.Distance(transform.position, lookTarget.position); //プレイヤーとの距離を算出する
 

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyStatus.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyStatus.cs
@@ -3,86 +3,21 @@ using System.Collections.Generic;
 using UnityEngine;
 
 
-
 public class EnemyStatus : CharacterStatus
-{
-    [Header("HPが0になってから消えるまでの時間")]
-    [SerializeField] float destroyDuration = 1f;
-    public float DestroyDuration
-    {
-        get { return destroyDuration; }
-        set { destroyDuration = value; }
-    }
-    [Header("撃破時のエフェクト")]
-    [SerializeField] GameObject deathEffect;
-
-
-    [Header("後ろに吹き飛ばされる力")]
-    [SerializeField] float knockbackForce_Back = 5f;
-    public float KnockBackForce_Back
-    {
-        get { return knockbackForce_Back; }
-        set { knockbackForce_Back = value; }
-    }
-    [Header("上に吹き飛ばされる力")]
-    [SerializeField] float knockbackForce_Up = 0.5f;
-    public float KnockBackForce_Up
-    {
-        get { return knockbackForce_Up; }
-        set { knockbackForce_Up = value; }
-    }
-   
+{   
     bool isDead = false;
     public bool IsDead { get { return isDead; } }
 
-    Rigidbody rb;
-    
-    [Header("いいね獲得数")]
-    [SerializeField] float getGoodNum;
 
     [Header("必要なコンポーネント")]
     [SerializeField] EnemyDeathHandler deathHandler;
 
-    //GoodSystem goodSystem;
-
-    void Awake()
-    {
-        rb = GetComponent<Rigidbody>();
-
-        
-
-        //goodSystem = GameObject.FindWithTag("GoodSystem").GetComponent<GoodSystem>();
-
-        
-    }
-
     private void Update()
     {
-        //if (!isDead && Hp <= 0) Die();
-        if (Hp <= 0 && !deathHandler.IsProcessing)
+        if (Hp <= 0 && !deathHandler.IsProcessing) //HPが0になった、かつ死亡時の処理が行われていない場合
         {
             isDead = true;
-            deathHandler.StartDeathProcess();
+            deathHandler.StartDeathProcess(); //死亡時の処理を開始する
         }
-    }
-
-    void Die()
-    {
-        isDead = true;
-
-        if (deathEffect != null) Instantiate(deathEffect, transform.position, Quaternion.identity);
-
-        // 向いている方向の反対に吹っ飛ぶ
-        Vector3 backwardForce = -transform.forward * knockbackForce_Back;
-        Vector3 upwardForce = Vector3.up * knockbackForce_Up;
-
-        // 吹き飛ばす
-        rb.AddForce(backwardForce + upwardForce, ForceMode.Impulse);
-
-        Destroy(gameObject, destroyDuration);
-
-        //いいね取得
-        //goodSystem.AddGood(getGoodNum);
-        //
     }
 }

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyStatus.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyStatus.cs
@@ -26,23 +26,24 @@ public class EnemyStatus : CharacterStatus
     }
     [Header("上に吹き飛ばされる力")]
     [SerializeField] float knockbackForce_Up = 0.5f;
- public float KnockBackForce_Up
+    public float KnockBackForce_Up
     {
         get { return knockbackForce_Up; }
         set { knockbackForce_Up = value; }
     }
-
-   
-
-    
-
    
     bool isDead = false;
+    public bool IsDead { get { return isDead; } }
+
     Rigidbody rb;
+    
     [Header("いいね獲得数")]
     [SerializeField] float getGoodNum;
 
-    GoodSystem goodSystem;
+    [Header("必要なコンポーネント")]
+    [SerializeField] EnemyDeathHandler deathHandler;
+
+    //GoodSystem goodSystem;
 
     void Awake()
     {
@@ -50,14 +51,19 @@ public class EnemyStatus : CharacterStatus
 
         
 
-        goodSystem = GameObject.FindWithTag("GoodSystem").GetComponent<GoodSystem>();
+        //goodSystem = GameObject.FindWithTag("GoodSystem").GetComponent<GoodSystem>();
 
         
     }
 
     private void Update()
     {
-        if (!isDead && Hp <= 0) Die();
+        //if (!isDead && Hp <= 0) Die();
+        if (Hp <= 0 && !deathHandler.IsProcessing)
+        {
+            isDead = true;
+            deathHandler.StartDeathProcess();
+        }
     }
 
     void Die()
@@ -76,7 +82,7 @@ public class EnemyStatus : CharacterStatus
         Destroy(gameObject, destroyDuration);
 
         //いいね取得
-        goodSystem.AddGood(getGoodNum);
+        //goodSystem.AddGood(getGoodNum);
         //
     }
 }


### PR DESCRIPTION
・敵のHPが0になった後、地面に設置している状態で一定時間経過後に消滅するようにしました。攻撃を受けるなどによって体　
　が地面から浮いた状態になると、時間経過をリセットして再度計測を始めます。

・EnemyStatusのコードに記述されていた死亡時の処理に使用される関数や変数を分離し、EnemyDeathHandlerにまとめまし　
　た。

・各EnemyPrefab -> EnemyDeathHandlerから、死亡時に発生する処理に関するパラメータを調整できます。

