### PR TITLE
敵を生成する機能の修正

### DIFF
--- a/Project_Live/Assets/Prefabs/EnemyPrefabs/Enemy_Big.prefab
+++ b/Project_Live/Assets/Prefabs/EnemyPrefabs/Enemy_Big.prefab
@@ -1,5 +1,81 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1638076717672335495
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6000796370541876364}
+  - component: {fileID: 3517984116219197449}
+  - component: {fileID: 4227629285071904794}
+  m_Layer: 0
+  m_Name: EnemySpawnArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6000796370541876364
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638076717672335495}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 278247329540723409}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &3517984116219197449
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638076717672335495}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 3, y: 0.1, z: 3}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4227629285071904794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638076717672335495}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 06f9fab46796a094aae21f8c4c4c4768, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spawnParameters:
+  - enemyPrefab: {fileID: 7764904506935383429, guid: b2acedd80aa7abb45b6324a2632b88a4, type: 3}
+    maxSpawnCount: 7
+    enemyType: 0
+  - enemyPrefab: {fileID: 8576028282158982197, guid: ab8394dab7a780b4096606b704093574, type: 3}
+    maxSpawnCount: 3
+    enemyType: 2
+  spawnArea: {fileID: 3517984116219197449}
+  enableRespawn: 0
+  checkInterval: 5
 --- !u!1001 &2503819622793431445
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -110,12 +186,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2405998444838165316, guid: b2acedd80aa7abb45b6324a2632b88a4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6000796370541876364}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 7764904506935383429, guid: b2acedd80aa7abb45b6324a2632b88a4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1476655089601252047}
   m_SourcePrefab: {fileID: 100100000, guid: b2acedd80aa7abb45b6324a2632b88a4, type: 3}
+--- !u!4 &278247329540723409 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2405998444838165316, guid: b2acedd80aa7abb45b6324a2632b88a4, type: 3}
+  m_PrefabInstance: {fileID: 2503819622793431445}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &5295425210205854736 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7764904506935383429, guid: b2acedd80aa7abb45b6324a2632b88a4, type: 3}

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemySpawnManager.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemySpawnScripts/EnemySpawnManager.cs
@@ -19,6 +19,8 @@ public class EnemySpawnManager : MonoBehaviour
     [SerializeField] List<SpawnParameter> spawnParameters;
     [Header("¶¬”ÍˆÍ")]
     [SerializeField] BoxCollider spawnArea;
+    [Header("“G‚ğÄ¶¬‚·‚é‚©‚Ç‚¤‚©")]
+    [SerializeField] bool enableRespawn = true;
     [Header("“G‚Ì”‚Ìƒ`ƒFƒbƒNŠÔŠu")]
     [SerializeField] float checkInterval = 1.0f;
 
@@ -26,6 +28,7 @@ public class EnemySpawnManager : MonoBehaviour
     Dictionary<EnemyType, EnemyCountTracker> trackers = new();
 
     float timer = 0f;
+
     void Start()
     {
         foreach (var param in spawnParameters) //İ’è‚³‚ê‚½“G‚Ìí—Ş‚Ì”‚¾‚¯ˆ—‚ğŒJ‚è•Ô‚·
@@ -35,8 +38,11 @@ public class EnemySpawnManager : MonoBehaviour
             spawners[param.enemyType].SpawnEnemies(param.maxSpawnCount); //“G‚Ì‰Šú¶¬
         }
     }
+
     void Update()
     {
+        if (!enableRespawn) return;
+
         timer += Time.deltaTime;
 
         foreach (var param in spawnParameters)


### PR DESCRIPTION
・ランダムな位置に生成されたリーダー格の敵を中心に、複数種類の敵を生成する仕組みに変更しました。
　リーダー格の敵の生成設定は従来通りEnemySpawnManagerから行うことができます。リーダーを中心とした敵の生成設定
　は、リーダー格の敵のプレハブに生成エリアを持たせ、そのエリアにアタッチしたEnemySpawnManagerから敵の生成設定を
　行う仕様にしました。

・プレイヤーの攻撃などによって敵が消滅した後、敵を再生成するかどうか設定できるようにしました。
　各EnemySpawnManagerから設定できます。