### PR TITLE
ボスの移動処理に関する不具合修正、エフェクトサイズの調整

### DIFF
--- a/Project_Live/Assets/Prefabs/EnemyPrefabs/Enemy_Boss.prefab
+++ b/Project_Live/Assets/Prefabs/EnemyPrefabs/Enemy_Boss.prefab
@@ -374,7 +374,6 @@ MonoBehaviour:
   chargeSound: {fileID: 8300000, guid: 4cb9546fc6b1b36489789682bc0d0372, type: 3}
   attackSound: {fileID: 8300000, guid: 1976bf5085a7ed44c98127b1524aaa87, type: 3}
   fallSound: {fileID: 8300000, guid: 7625caf70c0bc744eb27f3ff35f96a90, type: 3}
-  impactSound: {fileID: 8300000, guid: 4d881e49e28519246bf5cfc920793730, type: 3}
   meteorCount: 10
   minDistanceMeteors: 10
   timeToGround: 2
@@ -786,7 +785,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3718490458120221149, guid: 07419985e8993174696f9559c2e48540, type: 3}
       propertyPath: attackPatterns.Array.data[0].enableNormalAttack
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3718490458120221149, guid: 07419985e8993174696f9559c2e48540, type: 3}
       propertyPath: attackPatterns.Array.data[0].normalAttackWeight
@@ -842,7 +841,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3718490458120221149, guid: 07419985e8993174696f9559c2e48540, type: 3}
       propertyPath: attackPatterns.Array.data[0].enableLongRangeAttack
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3718490458120221149, guid: 07419985e8993174696f9559c2e48540, type: 3}
       propertyPath: attackPatterns.Array.data[0].longRangeAttackWeight

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyBoss/BossActions/LongRangeAttack_Boss.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyBoss/BossActions/LongRangeAttack_Boss.cs
@@ -41,6 +41,7 @@ public class LongRangeAttack_Boss : MonoBehaviour
 
     public bool IsActive { get { return isActive; } set { isActive = value; } }
     public bool IsAttacked { get; set; }
+    public Transform TargetPosion { get { return targetPosition; } }
     public AttackState CurrentAttackState { get { return currentAttackState; } set { currentAttackState = value; } }
     public void SetStartState()
     {
@@ -48,6 +49,7 @@ public class LongRangeAttack_Boss : MonoBehaviour
         previousAttackState = currentAttackState;
         hasArrived = false;
         targetPosition = null;
+        mover.ToggleActive(true, true);
     }
     
     void Start()
@@ -61,6 +63,8 @@ public class LongRangeAttack_Boss : MonoBehaviour
             stateMachine = GetComponentInParent<EnemyActionStateMachine>();
 
         if (status.IsDead || !isActive) return;
+
+        //Debug.Log(targetPosition);
         
         switch (currentAttackState)    
         {  
@@ -84,6 +88,8 @@ public class LongRangeAttack_Boss : MonoBehaviour
                         mover.MoveTowardsPlayer(targetPosition);
                         mover.LookPlayer(targetPosition);
                     }
+                    //Debug.Log(xzDistance);
+                    //Debug.Log(hasArrived);
                 }
 
                 if (hasArrived) currentAttackState = AttackState.Idle;

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyBoss/BossActions/MeteorFallAttack_Boss.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyBoss/BossActions/MeteorFallAttack_Boss.cs
@@ -62,6 +62,7 @@ public class MeteorFallAttack_Boss : MonoBehaviour
 
      public bool IsActive { get { return isActive; } set { isActive = value; } }
     public bool IsAttacked { get; set; }
+    public Transform TargetPosition { get { return targetPosition; } }
     public AttackState CurrentAttackState { get { return currentAttackState; } set { currentAttackState = value; } }
 
     public void SetStartState()
@@ -70,6 +71,7 @@ public class MeteorFallAttack_Boss : MonoBehaviour
         previousAttackState = currentAttackState;
         hasArrived = false;
         targetPosition = null;
+        mover.ToggleActive(true, true);
     }
 
     void Start()
@@ -83,6 +85,8 @@ public class MeteorFallAttack_Boss : MonoBehaviour
             stateMachine = GetComponentInParent<EnemyActionStateMachine>();
 
         if (status.IsDead || !isActive) return;
+
+        //Debug.Log(targetPosition);
 
         switch (currentAttackState)
         {
@@ -106,6 +110,9 @@ public class MeteorFallAttack_Boss : MonoBehaviour
                         mover.MoveTowardsPlayer(targetPosition);
                         mover.LookPlayer(targetPosition);
                     }
+
+                    //Debug.Log(xzDistance);
+                    //Debug.Log(hasArrived);
                 }
 
                 if (hasArrived) currentAttackState = AttackState.Idle;

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyBoss/BossStateScripts/BossStates/LongRangeAttackState_EnemyBoss.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyBoss/BossStateScripts/BossStates/LongRangeAttackState_EnemyBoss.cs
@@ -29,6 +29,9 @@ public class LongRangeAttackState_EnemyBoss : IEnemyState
     {
         longRangeAttack.StateProcess(); //‰“‹——£UŒ‚‚Ìˆ—
 
+        if (longRangeAttack.TargetPosion == null)
+            longRangeAttack.SetTargetPosition();
+
         if (!isPlayed && longRangeAttack.CurrentAttackState == LongRangeAttack_Boss.AttackState.Attack)
         {
             isPlayed = true;

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyBoss/BossStateScripts/BossStates/MeteorFallAttackState_EnemyBoss.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyBoss/BossStateScripts/BossStates/MeteorFallAttackState_EnemyBoss.cs
@@ -30,7 +30,9 @@ public class MeteorFallAttackState_EnemyBoss : IEnemyState
     {
         meteorFallAttack.StateProcess();
 
-        // çUåÇäÆóπîªíË
+        if (meteorFallAttack.TargetPosition == null)
+            meteorFallAttack.SetTargetPosition();
+
         if (!isPlayed && meteorFallAttack.CurrentAttackState == MeteorFallAttack_Boss.AttackState.Attack)
         {
             isPlayed = true;

--- a/Project_Live/Assets/Scripts/EnemyScripts/EnemyStateScripts/EnemyActionStateMachine.cs
+++ b/Project_Live/Assets/Scripts/EnemyScripts/EnemyStateScripts/EnemyActionStateMachine.cs
@@ -11,12 +11,6 @@ public class EnemyActionStateMachine : MonoBehaviour
     [Header("群れとボスのどちらの行動パターンを適用するか")]
     [SerializeField] bool isBossBehaviour = false;
 
-    //[Header("HP残量に応じて行動パターンの切り替えを適用するか")]
-    //[SerializeField] bool isPatternChangeEnable = false;
-    //[Header("ステート遷移を順番かランダムのどちらで行うか")]
-    //[Tooltip("チェックをつけると順番、外すとランダムで状態が遷移する")]
-    //[SerializeField] bool useSequentialOrder = true;
-
     public enum BossAttackType { Normal, LongRange, Area, MeteorFall }
 
     [System.Serializable]
@@ -52,7 +46,6 @@ public class EnemyActionStateMachine : MonoBehaviour
         [Tooltip("数値が大きいほど発動確率が高くなる")]
         [UnityEngine.Range(0f, 1f)]
         public float meteorFallAttackWeight = 1f;
-        //public List<BossAttackType> attackOrder = new List<BossAttackType>(); //順番指定用
     }
     [SerializeField] List<BossAttackPattern> attackPatterns =  new List<BossAttackPattern>();
 
@@ -75,8 +68,7 @@ public class EnemyActionStateMachine : MonoBehaviour
     float currentTimer = 0f;
     bool isDelayFinished;
 
-    public bool IsActive { get { return isActive; } set { isActive = value; } }
-    
+    public bool IsActive { get { return isActive; } set { isActive = value; } }    
     public IEnemyState CurrentState { get { return currentState; } }
     public bool IsBossBehaviour { get { return isBossBehaviour; } }
 
@@ -243,7 +235,16 @@ public class EnemyActionStateMachine : MonoBehaviour
             return;
         }
 
-        if (isBossBehaviour /*&& isPatternChangeEnable*/)
+        currentState?.Update();
+        //Debug.Log(currentState);
+        
+        if (status.Hp <= 0)
+        {
+            actionEvents.LostEvent();
+            return;
+        }
+
+        if (isBossBehaviour)
         {
             BossAttackPattern patternForHp = GetPatternForCurrentHp();
 
@@ -253,11 +254,6 @@ public class EnemyActionStateMachine : MonoBehaviour
                 OnBossAttackStartProcess();
             }
         }
-
-        if (status.Hp <= 0) actionEvents.LostEvent();
-
-        currentState?.Update();
-        //Debug.Log(currentState);
     }
 
     public void ChangeState(IEnemyState newState)
@@ -326,27 +322,4 @@ public class EnemyActionStateMachine : MonoBehaviour
         if (currentState is LostState_Enemy) return;
         ChangeState(new LostState_Enemy(anim));
     }
-
-    //void BuildBossAttackQueue(BossAttackQueue pattern)
-    //{
-    //    pattern.attackOrder.Clear();
-
-    //    if (pattern.enableNormalAttack) pattern.attackOrder.Add(BossAttackType.Normal);
-    //    if (pattern.enableLongRangeAttack) pattern.attackOrder.Add(BossAttackType.LongRange);
-    //    if (pattern.enableAreaAttack) pattern.attackOrder.Add(BossAttackType.Area);
-
-    //    if (!useSequentialOrder && pattern.attackOrder.Count > 1)
-    //        ShuffleAttackOrder(pattern);
-    //}
-
-    //void ShuffleAttackOrder(BossAttackQueue pattern) //攻撃内容のシャッフル
-    //{
-    //    for (int i = pattern.attackOrder.Count - 1; i > 0; i--)
-    //    {
-    //        int randomIndex = Random.Range(0, 0 + i);
-    //        var temp = pattern.attackOrder[i];
-    //        pattern.attackOrder[i] = pattern.attackOrder[randomIndex];
-    //        pattern.attackOrder[randomIndex] = temp;
-    //    }
-    //}
 }

--- a/Project_Live/Assets/Scripts/EtcScripts/DamageToTarget.cs
+++ b/Project_Live/Assets/Scripts/EtcScripts/DamageToTarget.cs
@@ -107,9 +107,12 @@ public class DamageToTarget : MonoBehaviour
         {
             Vector3 spawnPosition;
             Quaternion spawnRotation;
+            Vector3 effectScale = Vector3.one;
 
             if (enemy.gameObject.name.Contains("Enemy_Boss"))
             {
+                float enemyScaleX = enemy.transform.lossyScale.x;
+                effectScale = Vector3.one * enemyScaleX;
                 spawnPosition = effectSpawnPoint.position;
                 spawnRotation = effectSpawnPoint.rotation;
             }
@@ -120,7 +123,8 @@ public class DamageToTarget : MonoBehaviour
                 spawnRotation = enemy.gameObject.transform.rotation;
             }
             
-            Instantiate(hitEffect, spawnPosition, spawnRotation); //エフェクトが設定されていたら、命中時にエフェクトを生成する
+            GameObject effectInstance = Instantiate(hitEffect, spawnPosition, spawnRotation); //エフェクトが設定されていたら、命中時にエフェクトを生成する
+            effectInstance.transform.localScale = effectScale;
         }
 
         if (hitSound != null) SE.PlayOneShot(hitSound);


### PR DESCRIPTION
・ボスの攻撃状態遷移時に、ボスが動かなくなる不具合を修正しました。
・プレイヤーの攻撃がボスに命中時、ボスのスケールをもとにエフェクトサイズを調整するようにしました。